### PR TITLE
Alternative Shroomlight Recipe

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -210,14 +210,18 @@ G | I | G
 ### Shroomlights (`shroomlight`)
 
 ```
-  | G |
+  | S |
 - + - + -
-G | S | G
+S | G | S
 - + - + -
-  | G |
+  | S |
 
-[G]lowstone Dust
-{Brown,Red} Mu[S]hroom Block
+any Mu[S]hroom
+- Brown Mushroom
+- Red Mushroom
+- Warped Fungus
+- Crimson Fungus
+[G]lowstone Block
 ```
 
 ## Stonecutting Recipes (`stonecutting`)

--- a/src/main/java/de/kiridevs/ksmpplugin/recipes/crafting/ShroomlightRecipe.java
+++ b/src/main/java/de/kiridevs/ksmpplugin/recipes/crafting/ShroomlightRecipe.java
@@ -13,9 +13,11 @@ import de.kiridevs.ksmpplugin.main.KiriSmpPlugin;
 public class ShroomlightRecipe {
     private final KiriSmpPlugin plugin;
 
-    private static final MaterialChoice SHROOM_BLOCKS = new MaterialChoice(
-            Material.BROWN_MUSHROOM_BLOCK,
-            Material.RED_MUSHROOM_BLOCK
+    private static final MaterialChoice SHROOM_CHOICE = new MaterialChoice(
+            Material.BROWN_MUSHROOM,
+            Material.CRIMSON_FUNGUS,
+            Material.RED_MUSHROOM,
+            Material.WARPED_FUNGUS
     );
 
     public ShroomlightRecipe(KiriSmpPlugin plugin) {
@@ -29,9 +31,9 @@ public class ShroomlightRecipe {
         ItemStack result = new ItemStack(Material.SHROOMLIGHT);
 
         ShapedRecipe recipe = new ShapedRecipe(key, result)
-            .shape(" g ", "gsg", " g ")
-            .setIngredient('g', Material.GLOWSTONE_DUST)
-            .setIngredient('s', ShroomlightRecipe.SHROOM_BLOCKS);
+            .shape(" s ", "sgs", " s ")
+            .setIngredient('s', ShroomlightRecipe.SHROOM_CHOICE)
+            .setIngredient('g', Material.GLOWSTONE_DUST);
 
         this.plugin.log.info("recipes: ShroomlightRecipe: Registering Custom Recipe");
         Bukkit.addRecipe(recipe);

--- a/src/main/java/de/kiridevs/ksmpplugin/recipes/crafting/ShroomlightRecipe.java
+++ b/src/main/java/de/kiridevs/ksmpplugin/recipes/crafting/ShroomlightRecipe.java
@@ -33,7 +33,7 @@ public class ShroomlightRecipe {
         ShapedRecipe recipe = new ShapedRecipe(key, result)
             .shape(" s ", "sgs", " s ")
             .setIngredient('s', ShroomlightRecipe.SHROOM_CHOICE)
-            .setIngredient('g', Material.GLOWSTONE_DUST);
+            .setIngredient('g', Material.GLOWSTONE);
 
         this.plugin.log.info("recipes: ShroomlightRecipe: Registering Custom Recipe");
         Bukkit.addRecipe(recipe);


### PR DESCRIPTION
This PR changes the shroomlight recipe from **adding glowstone to a shroom block**:

```
  | G |  
- + - + -
G | B | G
- + - + -
  | G |  
```

![image](https://github.com/kiriDevs/ksmpplugin/assets/56218513/c9d57719-06d8-447f-bdef-c611a42a63e6)

to, instead **add mushrooms to glowstone**:

```
  | S |  
- + - + -
S | L | S
- + - + -
  | S |  
```

![image](https://github.com/kiriDevs/ksmpplugin/assets/56218513/278d8ab2-9f00-4019-940c-20e6bf7db8ba)

## Material Index

```
G - Glowstone Dust
L - Glowstone Block
S - Mushroom:
    - Brown Mushroom
    - Crimson Fungus
    - Red Mushroom
    - Warped Fungus
B - Mushroom Block:
    - Brown Mushroom Block
    - Red Mushroom Block
```

## Draft:

Which recipe will be used for kiriSMP5 will be decided by vote between the
players via the kiriSMP Discord. Until then, this PR will stay a draft.
